### PR TITLE
build: Bump kubewarden-policy-sdk to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61d7b51bf2aceddcb71944cd0ff45e9a15e0d5333e28fc2acc65e5f873cc3c5"
+checksum = "d6ed4b76c64427aee2e7d9fb1f4f110c1531722ce43694a8ea82950d57a3eb88"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 k8s-openapi = { version = "0.14.0", default_features = false, features = ["v1_23"] }
-kubewarden-policy-sdk = "0.4.1"
+kubewarden-policy-sdk = "0.4.2"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verify-image-signatures"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["raulcabello <raul.cabello@suse.com>","viccuad <vcuadradojuan@suse.de>"]
 edition = "2018"
 


### PR DESCRIPTION
To consume https://github.com/kubewarden/policy-sdk-rust/pull/38 for
more concise error string.

