### PR TITLE
feat: Add GithubActions and KeylessPrefix validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,7 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbeb0918c65e2beed24f7eadf69835b545045d1f1aabcb6a95e3282ea2e33ef"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df1e1d27c3191d89e483ddb7010d4aba1e159ba36307591ff8e4c0018ce1452"
+checksum = "0dbeb0918c65e2beed24f7eadf69835b545045d1f1aabcb6a95e3282ea2e33ef"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,8 @@ dependencies = [
 [[package]]
 name = "kubewarden-policy-sdk"
 version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4f07471a46151c3272d2ed0e3e62ecbae9b75ff374476c9468b54cd6b20a10"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -727,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "verify-image-signatures"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_24"] }
-kubewarden-policy-sdk = "0.6.0"
+kubewarden-policy-sdk = "0.6.2"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.7"
 wildmatch = "2.1.1"
+anyhow = "1.0.58"
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_24"] }
-kubewarden-policy-sdk = "0.6.2"
+kubewarden-policy-sdk = "0.6.3"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verify-image-signatures"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["raulcabello <raul.cabello@suse.com>","viccuad <vcuadradojuan@suse.de>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ signatures:
 ```
 
 url_prefix will match all subjects that starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
+`url_prefix` is sanitized to prevent typosquatting.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Signature types:
 signatures:
 - image: "ghcr.io/kubewarden/*"
   github_actions:
-    owner: "kubewarden" #optional
-    repo: "app-example"
+    owner: "kubewarden"
+    repo: "app-example" #optional
 ```
 
 2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`

--- a/README.md
+++ b/README.md
@@ -21,48 +21,48 @@ Signature types:
 
 1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`.
 
-``` yaml
-signatures:
-- image: "ghcr.io/kubewarden/*"
-  github_actions:
-    owner: "kubewarden"
-    repo: "app-example" #optional
-```
+  ``` yaml
+  signatures:
+  - image: "ghcr.io/kubewarden/*"
+    github_actions:
+      owner: "kubewarden"
+      repo: "app-example" #optional
+  ```
 
 2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
    `url_prefix` is sanitized to prevent typosquatting.
 
-``` yaml
-signatures:
-- image: "ghcr.io/kubewarden/*"
-  keyless_prefix:
-    - issuer: "https://token.actions.githubusercontent.com"
-      url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
-``` 
+  ``` yaml
+  signatures:
+  - image: "ghcr.io/kubewarden/*"
+    keyless_prefix:
+      - issuer: "https://token.actions.githubusercontent.com"
+        url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
+  ``` 
 
 
 3. Keyless exact match. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject is `kubewarden`. It will not modify the image with the digest.
 
-``` yaml
-modifyImagesWithDigest: false #optional. default is true
-signatures:
-  - image: "ghcr.io/kubewarden/*" 
-    keyless:
-      - issuer: "https://token.actions.githubusercontent.com"
-        subject: "kubewarden"
-``` 
+  ``` yaml
+  modifyImagesWithDigest: false #optional. default is true
+  signatures:
+    - image: "ghcr.io/kubewarden/*" 
+      keyless:
+        - issuer: "https://token.actions.githubusercontent.com"
+          subject: "kubewarden"
+  ``` 
 
 4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation.
 
-``` yaml
-signatures:
-  - image: "ghcr.io/kubewarden/*"
-    pubKeys: 
-      - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
-      - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
-    annotations: #optional
-      env: prod
-``` 
+  ``` yaml
+  signatures:
+    - image: "ghcr.io/kubewarden/*"
+      pubKeys: 
+        - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+        - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+      annotations: #optional
+        env: prod
+  ``` 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,53 +13,55 @@ See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/dist
 
 ## Settings
 
-The policy takes a list of signatures. A signature can be of two types: public key or keyless. Each signature
+The policy takes a list of signatures. A signature can be of four types: GitHub actions, public key, keyless exact match or keyless prefix. Each signature
 has an `image` field which will be used to select the matching containers in the pod that will be evaluated.
 `image` supports wildcard. For example, `ghcr.io/kubewarden/*` will match all images from the kubewarden ghcr repo.
 
-Example:
+Signature types:
 
-```yaml
-modifyImagesWithDigest: true #optional. default is true
-signatures:
-  - image: "*"
-    pubKeys: 
-      - ....
-    annotations: #optional
-      env: prod
-  - image: "ghcr.io/kubewarden/*" 
-    keyless:
-      - issuer: "https://token.actions.githubusercontent.com"
-        subject: "kubewarden"
-    annotations: #optional
-      env: prod
-```
+1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`
 
-This policy will validate all images with the public keys provided, and images whose name matches `ghcr.io/kubewarden/*` with the keyless provided.
-
-Another example that validates a GitHub action:
-
-```
+``` yaml
 signatures:
 - image: "ghcr.io/kubewarden/*"
+  owner: "kubewarden" #optional
   repo: "app-example"
-  owner: "kubewarden"
 ```
 
-This will validate the GitHub repo `app-example` for the `kubewarden` owner
+2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
+   `url_prefix` is sanitized to prevent typosquatting.
 
-And a url prefix example:
-
-```
+``` yaml
 signatures:
 - image: "ghcr.io/kubewarden/*"
   keyless_prefix:
     - issuer: "https://token.actions.githubusercontent.com"
       url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
-```
+``` 
 
-`url_prefix` will match all subjects that starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
-`url_prefix` is sanitized to prevent typosquatting.
+
+3. Keyless exact match. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject is `kubewarden`. It will not modify the image with the digest.
+
+``` yaml
+modifyImagesWithDigest: false #optional. default is true
+signatures:
+  - image: "ghcr.io/kubewarden/*" 
+    keyless:
+      - issuer: "https://token.actions.githubusercontent.com"
+        subject: "kubewarden"
+``` 
+
+4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation
+
+``` yaml
+signatures:
+  - image: "ghcr.io/kubewarden/*"
+    pubKeys: 
+      - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+      - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+    annotations: #optional
+      env: prod
+``` 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ signatures:
 
 This policy will validate all images with the public keys provided, and images whose name matches `ghcr.io/kubewarden/*` with the keyless provided.
 
-Another example that validates a github action:
+Another example that validates a GitHub action:
 
 ```
 signatures:
@@ -46,7 +46,7 @@ signatures:
   owner: "kubewarden"
 ```
 
-This will validate the github repo `app-example` for the `kubewarden` owner
+This will validate the GitHub repo `app-example` for the `kubewarden` owner
 
 And a url prefix example:
 
@@ -58,7 +58,7 @@ signatures:
       url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
 ```
 
-url_prefix will match all subjects that starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
+`url_prefix` will match all subjects that starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
 `url_prefix` is sanitized to prevent typosquatting.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ signatures:
 
 This policy will validate all images with the public keys provided, and images whose name matches `ghcr.io/kubewarden/*` with the keyless provided.
 
+Another example that validates a github action:
+
+```
+signatures:
+- image: "ghcr.io/kubewarden/*"
+  repo: "app-example"
+  owner: "kubewarden"
+```
+
+This will validate the github repo `app-example` for the `kubewarden` owner
+
+And a url prefix example:
+
+```
+signatures:
+- image: "ghcr.io/kubewarden/*"
+  keyless_prefix:
+    - issuer: "https://token.actions.githubusercontent.com"
+      url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
+```
+
+url_prefix will match all subjects that starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
+
 ## License
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ has an `image` field which will be used to select the matching containers in the
 
 Signature types:
 
-1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`
+1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`.
 
 ``` yaml
 signatures:
 - image: "ghcr.io/kubewarden/*"
-  owner: "kubewarden" #optional
-  repo: "app-example"
+  github_actions:
+    owner: "kubewarden" #optional
+    repo: "app-example"
 ```
 
 2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
@@ -51,7 +52,7 @@ signatures:
         subject: "kubewarden"
 ``` 
 
-4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation
+4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation.
 
 ``` yaml
 signatures:

--- a/metadata.yml
+++ b/metadata.yml
@@ -14,11 +14,63 @@ annotations:
   io.kubewarden.policy.source: https://github.com/kubewarden/verify-image-signatures
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.usage: |
-    This policy validates Sigstore signatures for containers, init container and ephemeral container that match the name provided
-    in the `image` settings field. It will reject the Pod if any validation fails.
-    If all signature validation pass or there is no container that matches the image name, the Pod will be accepted.
+  This policy validates Sigstore signatures for containers, init container and ephemeral container that match the name provided
+  in the `image` settings field. It will reject the Pod if any validation fails.
+  If all signature validation pass or there is no container that matches the image name, the Pod will be accepted.
+  
+  This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
+  This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
+  
+  See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/distributing-policies/secure-supply-chain) for more info.
+
+  ## Settings
+
+  The policy takes a list of signatures. A signature can be of four types: GitHub actions, public key, keyless exact match or keyless prefix. Each signature
+  has an `image` field which will be used to select the matching containers in the pod that will be evaluated.
+  `image` supports wildcard. For example, `ghcr.io/kubewarden/*` will match all images from the kubewarden ghcr repo.
+
+  Signature types:
+
+  1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`
+  
+  ``` yaml
+  signatures:
+    - image: "ghcr.io/kubewarden/*"
+      owner: "kubewarden" #optional
+      repo: "app-example"
+  ```
+  
+  2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
+  `url_prefix` is sanitized to prevent typosquatting.
+  
+  ``` yaml
+  signatures:
+    - image: "ghcr.io/kubewarden/*"
+      keyless_prefix:
+        - issuer: "https://token.actions.githubusercontent.com"
+          url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
+  ```
+  
+  3. Keyless exact match. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject is `kubewarden`. It will not modify the image with the digest.
+  
+  ``` yaml
+  modifyImagesWithDigest: false #optional. default is true
+  signatures:
+    - image: "ghcr.io/kubewarden/*"
+      keyless:
+        - issuer: "https://token.actions.githubusercontent.com"
+          subject: "kubewarden"
+  ```
+
+  4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation
     
-    This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
-    This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
-    
-    There are four types of signatures: GitHub actions, public key, keyless exact match and keyless prefix.
+    ``` yaml
+    signatures:
+      - image: "ghcr.io/kubewarden/*"
+        pubKeys:
+          - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+          - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+        annotations: #optional
+          env: prod
+    ```
+

--- a/metadata.yml
+++ b/metadata.yml
@@ -20,3 +20,5 @@ annotations:
     
     This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
     This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
+    
+    There are four types of signatures: GitHub actions, public key, keyless exact match and keyless prefix.

--- a/metadata.yml
+++ b/metadata.yml
@@ -28,42 +28,44 @@ annotations:
     The policy takes a list of signatures. A signature can be of four types: GitHub actions, public key, keyless exact match or keyless prefix. Each signature
     has an `image` field which will be used to select the matching containers in the pod that will be evaluated.
     `image` supports wildcard. For example, `ghcr.io/kubewarden/*` will match all images from the kubewarden ghcr repo.
-  
+
     Signature types:
-  
-    1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`
-    
-    ``` yaml
-    signatures:
+
+    1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`.
+
+      ``` yaml
+      signatures:
       - image: "ghcr.io/kubewarden/*"
-        owner: "kubewarden" #optional
-        repo: "app-example"
-    ```
-    
+        github_actions:
+          owner: "kubewarden"
+          repo: "app-example" #optional
+      ```
+
     2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
-    `url_prefix` is sanitized to prevent typosquatting.
-    
-    ``` yaml
-    signatures:
+       `url_prefix` is sanitized to prevent typosquatting.
+
+      ``` yaml
+      signatures:
       - image: "ghcr.io/kubewarden/*"
         keyless_prefix:
           - issuer: "https://token.actions.githubusercontent.com"
             url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
-    ```
-    
+      ```
+
+
     3. Keyless exact match. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject is `kubewarden`. It will not modify the image with the digest.
-    
-    ``` yaml
-    modifyImagesWithDigest: false #optional. default is true
-    signatures:
-      - image: "ghcr.io/kubewarden/*"
-        keyless:
-          - issuer: "https://token.actions.githubusercontent.com"
-            subject: "kubewarden"
-    ```
-  
-    4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation
-      
+
+      ``` yaml
+      modifyImagesWithDigest: false #optional. default is true
+      signatures:
+        - image: "ghcr.io/kubewarden/*"
+          keyless:
+            - issuer: "https://token.actions.githubusercontent.com"
+              subject: "kubewarden"
+      ```
+
+    4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation.
+
       ``` yaml
       signatures:
         - image: "ghcr.io/kubewarden/*"
@@ -73,4 +75,3 @@ annotations:
           annotations: #optional
             env: prod
       ```
-

--- a/metadata.yml
+++ b/metadata.yml
@@ -14,63 +14,63 @@ annotations:
   io.kubewarden.policy.source: https://github.com/kubewarden/verify-image-signatures
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.usage: |
-  This policy validates Sigstore signatures for containers, init container and ephemeral container that match the name provided
-  in the `image` settings field. It will reject the Pod if any validation fails.
-  If all signature validation pass or there is no container that matches the image name, the Pod will be accepted.
+    This policy validates Sigstore signatures for containers, init container and ephemeral container that match the name provided
+    in the `image` settings field. It will reject the Pod if any validation fails.
+    If all signature validation pass or there is no container that matches the image name, the Pod will be accepted.
+    
+    This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
+    This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
+    
+    See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/distributing-policies/secure-supply-chain) for more info.
   
-  This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
-  This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
+    ## Settings
   
-  See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/distributing-policies/secure-supply-chain) for more info.
-
-  ## Settings
-
-  The policy takes a list of signatures. A signature can be of four types: GitHub actions, public key, keyless exact match or keyless prefix. Each signature
-  has an `image` field which will be used to select the matching containers in the pod that will be evaluated.
-  `image` supports wildcard. For example, `ghcr.io/kubewarden/*` will match all images from the kubewarden ghcr repo.
-
-  Signature types:
-
-  1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`
+    The policy takes a list of signatures. A signature can be of four types: GitHub actions, public key, keyless exact match or keyless prefix. Each signature
+    has an `image` field which will be used to select the matching containers in the pod that will be evaluated.
+    `image` supports wildcard. For example, `ghcr.io/kubewarden/*` will match all images from the kubewarden ghcr repo.
   
-  ``` yaml
-  signatures:
-    - image: "ghcr.io/kubewarden/*"
-      owner: "kubewarden" #optional
-      repo: "app-example"
-  ```
+    Signature types:
   
-  2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
-  `url_prefix` is sanitized to prevent typosquatting.
-  
-  ``` yaml
-  signatures:
-    - image: "ghcr.io/kubewarden/*"
-      keyless_prefix:
-        - issuer: "https://token.actions.githubusercontent.com"
-          url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
-  ```
-  
-  3. Keyless exact match. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject is `kubewarden`. It will not modify the image with the digest.
-  
-  ``` yaml
-  modifyImagesWithDigest: false #optional. default is true
-  signatures:
-    - image: "ghcr.io/kubewarden/*"
-      keyless:
-        - issuer: "https://token.actions.githubusercontent.com"
-          subject: "kubewarden"
-  ```
-
-  4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation
+    1. GitHub actions. It will verify that all images were signed for a GitHub action with the `kubewarden` owner and in the repo `app-example`
     
     ``` yaml
     signatures:
       - image: "ghcr.io/kubewarden/*"
-        pubKeys:
-          - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
-          - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
-        annotations: #optional
-          env: prod
+        owner: "kubewarden" #optional
+        repo: "app-example"
     ```
+    
+    2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
+    `url_prefix` is sanitized to prevent typosquatting.
+    
+    ``` yaml
+    signatures:
+      - image: "ghcr.io/kubewarden/*"
+        keyless_prefix:
+          - issuer: "https://token.actions.githubusercontent.com"
+            url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
+    ```
+    
+    3. Keyless exact match. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject is `kubewarden`. It will not modify the image with the digest.
+    
+    ``` yaml
+    modifyImagesWithDigest: false #optional. default is true
+    signatures:
+      - image: "ghcr.io/kubewarden/*"
+        keyless:
+          - issuer: "https://token.actions.githubusercontent.com"
+            subject: "kubewarden"
+    ```
+  
+    4. Public key. It will verify that all images were signed with the two public keys provided and contains the `env: prod` annotation
+      
+      ``` yaml
+      signatures:
+        - image: "ghcr.io/kubewarden/*"
+          pubKeys:
+            - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+            - "-----BEGIN PUBLIC KEY-----xxxxx-----END PUBLIC KEY-----"
+          annotations: #optional
+            env: prod
+      ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,8 +226,7 @@ where
                         handle_verification_response(
                             verify_keyless_github_actions(
                                 container_image.as_str(),
-                                s.owner.clone(),
-                                s.repo.clone(),
+                                s.github_actions.clone(),
                                 s.annotations.clone(),
                             ),
                             container_image.as_str(),
@@ -290,7 +289,7 @@ mod tests {
     use crate::settings::{GithubActions, Keyless, KeylessPrefix, PubKeys};
     use anyhow::anyhow;
     use kubewarden::host_capabilities::verification::{
-        KeylessInfo, KeylessPrefixInfo, VerificationResponse,
+        KeylessGithubActionsInfo, KeylessInfo, KeylessPrefixInfo, VerificationResponse,
     };
     use kubewarden::test::Testcase;
     use mockall::automock;
@@ -301,7 +300,7 @@ mod tests {
     pub mod sdk {
         use anyhow::Result;
         use kubewarden::host_capabilities::verification::{
-            KeylessInfo, KeylessPrefixInfo, VerificationResponse,
+            KeylessGithubActionsInfo, KeylessInfo, KeylessPrefixInfo, VerificationResponse,
         };
         use std::collections::HashMap;
 
@@ -348,8 +347,7 @@ mod tests {
         #[allow(dead_code)]
         pub fn verify_keyless_github_actions(
             _image: &str,
-            _owner: String,
-            _repo: Option<String>,
+            _github_actions: KeylessGithubActionsInfo,
             _annotations: Option<HashMap<String, String>>,
         ) -> Result<VerificationResponse> {
             Ok(VerificationResponse {
@@ -805,7 +803,7 @@ mod tests {
     #[serial]
     fn keyless_github_action_validation_pass_and_dont_mutate_if_digest_is_present() {
         let ctx = mock_sdk::verify_keyless_github_actions_context();
-        ctx.expect().times(1).returning(|_, _, _, _| {
+        ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
                 digest: "sha256:89102e348749bb17a6a651a4b2a17420e1a66d2a44a675b981973d49a5af3a5e"
@@ -816,8 +814,10 @@ mod tests {
         let settings: Settings = Settings {
             signatures: vec![Signature::GithubActions(GithubActions {
                 image: "nginx:*".to_string(),
-                repo: Some("repo".to_string()),
-                owner: "owner".to_string(),
+                github_actions: KeylessGithubActionsInfo {
+                    owner: "owner".to_string(),
+                    repo: Some("repo".to_string()),
+                },
                 annotations: None,
             })],
             modify_images_with_digest: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,8 @@ where
                         handle_verification_response(
                             verify_keyless_github_actions(
                                 container_image.as_str(),
-                                s.github_actions.clone(),
+                                s.github_actions.owner.clone(),
+                                s.github_actions.repo.clone(),
                                 s.annotations.clone(),
                             ),
                             container_image.as_str(),
@@ -286,10 +287,12 @@ fn add_digest_if_not_present<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::{GithubActions, Keyless, KeylessPrefix, PubKeys};
+    use crate::settings::{
+        GithubActions, Keyless, KeylessGithubActionsInfo, KeylessPrefix, PubKeys,
+    };
     use anyhow::anyhow;
     use kubewarden::host_capabilities::verification::{
-        KeylessGithubActionsInfo, KeylessInfo, KeylessPrefixInfo, VerificationResponse,
+        KeylessInfo, KeylessPrefixInfo, VerificationResponse,
     };
     use kubewarden::test::Testcase;
     use mockall::automock;
@@ -300,7 +303,7 @@ mod tests {
     pub mod sdk {
         use anyhow::Result;
         use kubewarden::host_capabilities::verification::{
-            KeylessGithubActionsInfo, KeylessInfo, KeylessPrefixInfo, VerificationResponse,
+            KeylessInfo, KeylessPrefixInfo, VerificationResponse,
         };
         use std::collections::HashMap;
 
@@ -347,7 +350,8 @@ mod tests {
         #[allow(dead_code)]
         pub fn verify_keyless_github_actions(
             _image: &str,
-            _github_actions: KeylessGithubActionsInfo,
+            _owner: String,
+            _repo: Option<String>,
             _annotations: Option<HashMap<String, String>>,
         ) -> Result<VerificationResponse> {
             Ok(VerificationResponse {
@@ -803,7 +807,7 @@ mod tests {
     #[serial]
     fn keyless_github_action_validation_pass_and_dont_mutate_if_digest_is_present() {
         let ctx = mock_sdk::verify_keyless_github_actions_context();
-        ctx.expect().times(1).returning(|_, _, _| {
+        ctx.expect().times(1).returning(|_, _, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
                 digest: "sha256:89102e348749bb17a6a651a4b2a17420e1a66d2a44a675b981973d49a5af3a5e"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
 use crate::LOG_DRAIN;
-use kubewarden::host_capabilities::verification::KeylessInfo;
+use kubewarden::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,8 @@ pub(crate) struct Settings {
 pub(crate) enum Signature {
     PubKeys(PubKeys),
     Keyless(Keyless),
+    GithubActions(GithubActions),
+    KeylessPrefix(KeylessPrefix),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -37,6 +39,28 @@ pub(crate) struct PubKeys {
 pub(crate) struct Keyless {
     pub(crate) image: String,
     pub(crate) keyless: Vec<KeylessInfo>,
+    pub(crate) annotations: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct GithubActions {
+    /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+    pub(crate) image: String,
+    /// owner of the repository. E.g: octocat
+    pub(crate) owner: String,
+    /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
+    pub(crate) repo: Option<String>,
+    /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
+    pub(crate) annotations: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct KeylessPrefix {
+    /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+    pub(crate) image: String,
+    /// List of keyless signatures that must be found
+    pub(crate) keyless_prefix: Vec<KeylessPrefixInfo>,
+    /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
     pub(crate) annotations: Option<HashMap<String, String>>,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,5 @@
 use crate::LOG_DRAIN;
-use kubewarden::host_capabilities::verification::{
-    KeylessGithubActionsInfo, KeylessInfo, KeylessPrefixInfo,
-};
+use kubewarden::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -42,6 +40,14 @@ pub(crate) struct Keyless {
     pub(crate) image: String,
     pub(crate) keyless: Vec<KeylessInfo>,
     pub(crate) annotations: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct KeylessGithubActionsInfo {
+    /// owner of the repository. E.g: octocat
+    pub(crate) owner: String,
+    /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
+    pub(crate) repo: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,7 @@
 use crate::LOG_DRAIN;
-use kubewarden::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
+use kubewarden::host_capabilities::verification::{
+    KeylessGithubActionsInfo, KeylessInfo, KeylessPrefixInfo,
+};
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -46,10 +48,8 @@ pub(crate) struct Keyless {
 pub(crate) struct GithubActions {
     /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
     pub(crate) image: String,
-    /// owner of the repository. E.g: octocat
-    pub(crate) owner: String,
-    /// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
-    pub(crate) repo: Option<String>,
+    // GitHub Actions information that must be found in the signature
+    pub(crate) github_actions: KeylessGithubActionsInfo,
     /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
     pub(crate) annotations: Option<HashMap<String, String>>,
 }


### PR DESCRIPTION
Consume the verify_keyless_github_actions and verify_keyless_prefix_match methods from the sdk, in order to allow user to verify github actions and use a url prefix for subject validation

Fix #24 