### PR TITLE
fix policy metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "verify-image-signatures"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verify-image-signatures"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["raulcabello <raul.cabello@suse.com>","viccuad <vcuadradojuan@suse.de>"]
 edition = "2018"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SOURCE_FILES := $(shell test -e src/ && find src -type f)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
 	cargo build --target=wasm32-unknown-unknown --release
-	mv target/wasm32-unknown-unknown/release/*.wasm policy.wasm
+	cp target/wasm32-unknown-unknown/release/*.wasm policy.wasm
 
 annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -o annotated-policy.wasm policy.wasm

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.5
+version: 0.1.6
 name: verify-image-signatures
 displayName: Verify Image Signatures
 createdAt: '2022-07-19T16:28:15+02:00'
@@ -9,13 +9,7 @@ license: Apache-2.0
 homeURL: https://github.com/kubewarden/verify-image-signatures
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/verify-image-signatures:v0.1.5
-install: |
-  The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl/):
-
-  ```console
-  kwctl pull ghcr.io/kubewarden/policies/verify-image-signatures:v0.1.5
-  ```
+  image: ghcr.io/kubewarden/policies/verify-image-signatures:v0.1.6
 keywords:
 - pod
 - signature
@@ -23,7 +17,7 @@ keywords:
 - trusted
 links:
 - name: policy
-  url: https://github.com/kubewarden/verify-image-signatures/releases/download/v0.1.5/policy.wasm
+  url: https://github.com/kubewarden/verify-image-signatures/releases/download/v0.1.6/policy.wasm
 - name: source
   url: https://github.com/kubewarden/verify-image-signatures
 provider:

--- a/e2e.bats
+++ b/e2e.bats
@@ -1,16 +1,42 @@
 #!/usr/bin/env bats
 
 @test "Accept a valid signature" {
-	run kwctl run  --request-path test_data/pod_creation_signed.json --settings-path test_data/settings.yaml annotated-policy.wasm
-	[ "$status" -eq 0 ]
-	echo "$output"
-	[ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
- }
+  run kwctl run  --request-path test_data/pod_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
 
 @test "Reject invalid signature" {
-	run kwctl run  --request-path test_data/pod_creation_unsigned.json --settings-path test_data/settings.yaml annotated-policy.wasm
+  run kwctl run  --request-path test_data/pod_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*"message":"Pod invalid-pod-name is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}
+
+@test "Mutate Pod definition" {
+  # Need to run the command inside of `bash -c` because of a bats
+  # limitation: https://bats-core.readthedocs.io/en/stable/gotchas.html?highlight=pipe#my-piped-command-does-not-work-under-run
+
+  run bash -c 'kwctl run \
+    --request-path test_data/pod_creation_signed.json \
+    --settings-path test_data/settings-mutation-enabled.yaml \
+    annotated-policy.wasm | jq -r ".patch | @base64d"'
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*ghcr.io/kubewarden/test-verify-image-signatures:signed@sha256:1d9d3da4c60d27b77bb96bba738319c1c4424853fdd10f65982f9f2ca2422a72.*') -ne 0 ]
+}
+
+@test "Do not mutate Pod definition" {
+  # Need to run the command inside of `bash -c` because of a bats
+  # limitation: https://bats-core.readthedocs.io/en/stable/gotchas.html?highlight=pipe#my-piped-command-does-not-work-under-run
+
+	run bash -c 'kwctl run \
+    --request-path test_data/pod_creation_signed.json \
+    --settings-path test_data/settings-mutation-disabled.yaml \
+    annotated-policy.wasm | jq -r ".patch"'
 	[ "$status" -eq 0 ]
 	echo "$output"
-	[ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
-	[ $(expr "$output" : '.*"message":"Pod invalid-pod-name is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
- }
+	[ $(expr "$output" : 'null') -ne 0 ]
+}

--- a/metadata.yml
+++ b/metadata.yml
@@ -2,8 +2,8 @@ rules:
 - apiGroups: [""]
   apiVersions: ["v1"]
   resources: ["pods"]
-  operations: ["CREATE"]
-mutating: false
+  operations: ["CREATE", "UPDATE"]
+mutating: true
 contextAware: false
 executionMode: kubewarden-wapc
 annotations:
@@ -17,14 +17,14 @@ annotations:
     This policy validates Sigstore signatures for containers, init container and ephemeral container that match the name provided
     in the `image` settings field. It will reject the Pod if any validation fails.
     If all signature validation pass or there is no container that matches the image name, the Pod will be accepted.
-    
+
     This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
     This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
-    
+
     See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/distributing-policies/secure-supply-chain) for more info.
-  
+
     ## Settings
-  
+
     The policy takes a list of signatures. A signature can be of four types: GitHub actions, public key, keyless exact match or keyless prefix. Each signature
     has an `image` field which will be used to select the matching containers in the pod that will be evaluated.
     `image` supports wildcard. For example, `ghcr.io/kubewarden/*` will match all images from the kubewarden ghcr repo.

--- a/test_data/settings-mutation-disabled.yaml
+++ b/test_data/settings-mutation-disabled.yaml
@@ -1,3 +1,4 @@
+modifyImagesWithDigest: false
 signatures:
   - image: "ghcr.io/kubewarden/*"
     pubKeys:

--- a/test_data/settings-mutation-enabled.yaml
+++ b/test_data/settings-mutation-enabled.yaml
@@ -1,0 +1,10 @@
+# No need to set modifyImagesWithDigest to `true` - this is the default
+# behavior
+signatures:
+  - image: ghcr.io/kubewarden/test-verify-image-signatures
+    pubKeys:
+      - |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEALYYVLuPXXcKajo5meRcU+c6/iZe
+        Dh+o3ZZs1puVW5FyS1cOusnLn209R0IOFL479vm1iFn+auB41JJZUxfc8g==
+        -----END PUBLIC KEY-----

--- a/test_data/settings-mutation-enabled.yaml
+++ b/test_data/settings-mutation-enabled.yaml
@@ -1,7 +1,7 @@
 # No need to set modifyImagesWithDigest to `true` - this is the default
 # behavior
 signatures:
-  - image: ghcr.io/kubewarden/test-verify-image-signatures
+  - image: "ghcr.io/kubewarden/*"
     pubKeys:
       - |
         -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
Some small fixes, a new version of the policy has to be tagged once this is merged.

## Policy metadata

The policy metadata didn't mark the policy as being able to mutate. This would lead to `kwctl scaffold` produce wrong output.

Moreover, the metadata has been extended to make scaffold generate a policy that evaluates also `UPDATE` operations.

## end to end tests

- Allow make e2e-tests to be run multiple times
- Extend e2e test: cover also the mutation capabilities

## Artifact Hub metadata

Remove the `install` section from the metadata file. This is now automatically created by Artifact Hub
