### PR TITLE
Check workload resources that can instantiate containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,34 @@ If all signature validation pass or there is no container that matches the image
 This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change. 
 This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
 
+It can also reject all workload resources that contain containers: Deployments, ReplicaSets, StatefulSets, DaemonSets, Jobs, CronJobs, ReplicationControllers
+For this you need to add these resources in the rules field of the policy. 
+
+Example of a policy that will reject any workload resources mentioned before:
+
+``` yaml
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: verify-image-signatures
+spec:
+  module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.1.7
+  rules:
+  - apiGroups: ["", "apps", "batch"]
+    apiVersions: ["v1"]
+    resources: ["pods", "deployments", "statefulsets", "replicationcontrollers", "jobs", "cronjobs"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: true
+  settings:
+    signatures:
+    - image: "*"
+      github_actions:
+        owner: "kubewarden"
+        repo: "app-example" 
+```
+
 See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/distributing-policies/secure-supply-chain) for more info.
 
 ## Settings

--- a/e2e.bats
+++ b/e2e.bats
@@ -40,3 +40,93 @@
 	echo "$output"
 	[ $(expr "$output" : 'null') -ne 0 ]
 }
+
+@test "Accept a valid signature in a Deployment" {
+  run kwctl run  --request-path test_data/deployment_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject invalid signature in a Deployment" {
+  run kwctl run  --request-path test_data/deployment_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}
+
+@test "Accept a valid signature in a StatefulSet" {
+  run kwctl run  --request-path test_data/statefulset_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject invalid signature in a StatefulSet" {
+  run kwctl run  --request-path test_data/statefulset_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}
+
+@test "Accept a valid signature in a ReplicaSet" {
+  run kwctl run  --request-path test_data/replicaset_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject invalid signature in a ReplicaSet" {
+  run kwctl run  --request-path test_data/replicaset_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}
+
+@test "Accept a valid signature in a ReplicationController" {
+  run kwctl run  --request-path test_data/replicationcontroller_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject invalid signature in a ReplicationController" {
+  run kwctl run  --request-path test_data/replicationcontroller_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}
+
+@test "Accept a valid signature in a Job" {
+  run kwctl run  --request-path test_data/job_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject invalid signature in a Job" {
+  run kwctl run  --request-path test_data/job_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}
+
+@test "Accept a valid signature in a CronJob" {
+  run kwctl run  --request-path test_data/cronjob_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":true.*') -ne 0 ]
+}
+
+@test "Reject invalid signature in a CronJob" {
+  run kwctl run  --request-path test_data/cronjob_creation_unsigned.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
+  [ "$status" -eq 0 ]
+  echo "$output"
+  [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
+  [ $(expr "$output" : '.*is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+}

--- a/metadata.yml
+++ b/metadata.yml
@@ -21,6 +21,34 @@ annotations:
     This policy also mutates matching images to add the image digest, therefore the version of the deployed image can't change.
     This mutation can be disabled by setting `modifyImagesWithDigest` to `false`.
 
+    It can also reject all workload resources that contain containers: Deployments, ReplicaSets, StatefulSets, DaemonSets, Jobs, CronJobs, ReplicationControllers
+    For this you need to add these resources in the rules field of the policy.
+
+    Example of a policy that will reject any workload resources mentioned before:
+  
+    ``` yaml
+    apiVersion: policies.kubewarden.io/v1
+    kind: ClusterAdmissionPolicy
+    metadata:
+      name: verify-image-signatures
+    spec:
+      module: ghcr.io/kubewarden/policies/verify-image-signatures:v0.1.7
+      rules:
+        - apiGroups: ["", "apps", "batch"]
+          apiVersions: ["v1"]
+          resources: ["pods", "deployments", "statefulsets", "replicationcontrollers", "jobs", "cronjobs"]
+          operations:
+            - CREATE
+            - UPDATE
+      mutating: true
+      settings:
+        signatures:
+          - image: "*"
+            github_actions:
+              owner: "kubewarden"
+              repo: "app-example"
+    ```
+    
     See the [Secure Supply Chain docs in Kubewarden](https://docs.kubewarden.io/distributing-policies/secure-supply-chain) for more info.
 
     ## Settings

--- a/test_data/cronjob_creation_signed.json
+++ b/test_data/cronjob_creation_signed.json
@@ -1,0 +1,41 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "CronJob",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "schedule": "* * * * *",
+      "jobTemplate": {
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+                  "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+                  "name": "test-verify-image-signatures"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Job"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/cronjob_creation_unsigned.json
+++ b/test_data/cronjob_creation_unsigned.json
@@ -1,0 +1,41 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "CronJob",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "schedule": "* * * * *",
+      "jobTemplate": {
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+                  "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+                  "name": "test-verify-image-signatures"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Job"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/daemonset_creation_signed.json
+++ b/test_data/daemonset_creation_signed.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "DaemonSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "DaemonSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/daemonset_creation_unsigned.json
+++ b/test_data/daemonset_creation_unsigned.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "DaemonSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "DaemonSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/deployment_creation_signed.json
+++ b/test_data/deployment_creation_signed.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Deployment"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/deployment_creation_unsigned.json
+++ b/test_data/deployment_creation_unsigned.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Deployment"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/job_creation_signed.json
+++ b/test_data/job_creation_signed.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "Job",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Job"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/job_creation_unsigned.json
+++ b/test_data/job_creation_unsigned.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "Job",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Job"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/replicaset_creation_signed.json
+++ b/test_data/replicaset_creation_signed.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "ReplicaSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "ReplicaSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/replicaset_creation_unsigned.json
+++ b/test_data/replicaset_creation_unsigned.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "ReplicaSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "ReplicaSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/replicationcontroller_creation_signed.json
+++ b/test_data/replicationcontroller_creation_signed.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "ReplicationController",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "ReplicationController"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/replicationcontroller_creation_unsigned.json
+++ b/test_data/replicationcontroller_creation_unsigned.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "ReplicationController",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "ReplicationController"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/statefulset_creation_signed.json
+++ b/test_data/statefulset_creation_signed.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "StatefulSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:signed",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "StatefulSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/statefulset_creation_unsigned.json
+++ b/test_data/statefulset_creation_unsigned.json
@@ -1,0 +1,36 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "StatefulSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "ghcr.io/kubewarden/test-verify-image-signatures:unsigned",
+              "name": "test-verify-image-signatures"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "StatefulSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}


### PR DESCRIPTION
Check Deployments, ReplicaSets, StatefulSets, DaemonSets, Jobs, CronJobs, ReplicationControllers so they are evaluated before creation. This provides instant feedback to the user instead of wating to see if pods are created.

Fix #22 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

[ghcr.io/raulcabello/policies/verify-image-signatures:v0.0.0.test6](https://github.com/raulcabello/verify-image-signatures/pkgs/container/policies%2Fverify-image-signatures/36723533?tag=v0.0.0.test6) can be used for testing