### PR TITLE
Relax `anyhow` requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.7"
 wildmatch = "2.1.1"
-anyhow = "1.0.62"
+anyhow = "1.0"
 
 [dev-dependencies]
 rstest = "0.15.0"
 serial_test = "0.9.0"
 mockall = "0.11.2"
-anyhow = "1"


### PR DESCRIPTION
* Do not specify a patch release
* Update to latest stable release of anyhow
* Remove `anyhow` from the dev-dependencies, this is already a build time dep. There's no need to duplicate it

Supersedes https://github.com/kubewarden/verify-image-signatures/pull/34

