### PR TITLE
feat: implement certificate verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cfefe4b5fae7a635ad251108ff25efaa53db320e0cb1f3438de87424f91bd9"
+checksum = "3983ae33f19888b3bc085dc11d598a6eca47d1872547b32633c2753acd62cee1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 k8s-openapi = { version = "0.16.0", default_features = false, features = ["v1_24"] }
-kubewarden-policy-sdk = "0.8.2"
+kubewarden-policy-sdk = "0.8.3"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Signature types:
       certificate_chain:
       - |
         -----BEGIN CERTIFICATE-----
-        XXX
+        <intermediate cert>
         -----END CERTIFICATE-----
       - |
         -----BEGIN CERTIFICATE-----

--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ Signature types:
         env: prod
   ``` 
 
+5. Certificate. It will verify that the image has been signed using the Certificate provided by the user.
+  The `certificate` must be PEM encoded. Optionally the settings can have
+  the list of PEM encoded certificates that can create the `certificate_chain`
+  used to verify the given `certificate`.
+  The `require_rekor_bundle` should be set to `true` to have a stronger
+  verification process. When set to `true`, the signature must have a Rekor
+  bundle and the signature must have been created during the validity
+  time frame of the `certificate`.
+
+  ```yaml
+  signatures:
+    - image: "registry-testing.svc.lan/kubewarden/pod-privileged:v0.1.9"
+      certificate: |
+        -----BEGIN CERTIFICATE-----
+        XXX
+        -----END CERTIFICATE-----
+      certificate_chain:
+      - |
+        -----BEGIN CERTIFICATE-----
+        XXX
+        -----END CERTIFICATE-----
+      - |
+        -----BEGIN CERTIFICATE-----
+        xxx
+        -----END CERTIFICATE-----
+      require_rekor_bundle: true
+  ```
+
 ## License
 
 ```

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Signature types:
         -----END CERTIFICATE-----
       - |
         -----BEGIN CERTIFICATE-----
-        xxx
+        <root CA>
         -----END CERTIFICATE-----
       require_rekor_bundle: true
   ```

--- a/metadata.yml
+++ b/metadata.yml
@@ -103,3 +103,31 @@ annotations:
           annotations: #optional
             env: prod
       ```
+
+    5. Certificate. It will verify that the image has been signed using the Certificate provided by the user.
+      The `certificate` must be PEM encoded. Optionally the settings can have
+      the list of PEM encoded certificates that can create the `certificate_chain`
+      used to verify the given `certificate`.
+      The `require_rekor_bundle` should be set to `true` to have a stronger
+      verification process. When set to `true`, the signature must have a Rekor
+      bundle and the signature must have been created during the validity
+      time frame of the `certificate`.
+
+      ```yaml
+      signatures:
+        - image: "registry-testing.svc.lan/kubewarden/pod-privileged:v0.1.9"
+          certificate: |
+            -----BEGIN CERTIFICATE-----
+            XXX
+            -----END CERTIFICATE-----
+          certificate_chain:
+          - |
+            -----BEGIN CERTIFICATE-----
+            XXX
+            -----END CERTIFICATE-----
+          - |
+            -----BEGIN CERTIFICATE-----
+            xxx
+            -----END CERTIFICATE-----
+          require_rekor_bundle: true
+      ```

--- a/metadata.yml
+++ b/metadata.yml
@@ -123,11 +123,11 @@ annotations:
           certificate_chain:
           - |
             -----BEGIN CERTIFICATE-----
-            XXX
+            <intermediate cert>
             -----END CERTIFICATE-----
           - |
             -----BEGIN CERTIFICATE-----
-            xxx
+            <root CA>
             -----END CERTIFICATE-----
           require_rekor_bundle: true
       ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ trait ValidatingResource {
 
 impl ValidatingResource for Deployment {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -90,7 +90,7 @@ impl ValidatingResource for Deployment {
 
 impl ValidatingResource for ReplicaSet {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -100,7 +100,7 @@ impl ValidatingResource for ReplicaSet {
 
 impl ValidatingResource for StatefulSet {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -110,7 +110,7 @@ impl ValidatingResource for StatefulSet {
 
 impl ValidatingResource for DaemonSet {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -120,7 +120,7 @@ impl ValidatingResource for DaemonSet {
 
 impl ValidatingResource for ReplicationController {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -130,7 +130,7 @@ impl ValidatingResource for ReplicationController {
 
 impl ValidatingResource for Job {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -140,7 +140,7 @@ impl ValidatingResource for Job {
 
 impl ValidatingResource for CronJob {
     fn name(&self) -> String {
-        self.metadata.name.clone().unwrap_or_else(|| "".to_string())
+        self.metadata.name.clone().unwrap_or_default()
     }
 
     fn spec(&self) -> Option<PodSpec> {
@@ -551,13 +551,11 @@ mod tests {
         });
 
         let settings: Settings = Settings {
-            signatures: vec![Signature::PubKeys {
-                0: PubKeys {
+            signatures: vec![Signature::PubKeys(PubKeys {
                     image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
                     pub_keys: vec!["key".to_string()],
                     annotations: None,
-                },
-            }],
+                })],
             modify_images_with_digest: true,
         };
 
@@ -602,13 +600,11 @@ mod tests {
         });
 
         let settings: Settings = Settings {
-            signatures: vec![Signature::PubKeys {
-                0: PubKeys {
+            signatures: vec![Signature::PubKeys(PubKeys {
                     image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
                     pub_keys: vec!["key".to_string()],
                     annotations: None,
-                },
-            }],
+                })],
             modify_images_with_digest: false,
         };
 
@@ -633,13 +629,11 @@ mod tests {
             .returning(|_, _, _| Err(anyhow!("error")));
 
         let settings: Settings = Settings {
-            signatures: vec![Signature::PubKeys {
-                0: PubKeys {
+            signatures: vec![Signature::PubKeys(PubKeys {
                     image: "*".to_string(),
                     pub_keys: vec!["key".to_string()],
                     annotations: None,
-                },
-            }],
+                })],
             modify_images_with_digest: true,
         };
 
@@ -682,7 +676,7 @@ mod tests {
         let tc = Testcase {
             name: String::from("It should successfully validate the nginx container"),
             fixture_file: String::from("test_data/pod_creation_signed.json"),
-            settings: settings,
+            settings,
             expected_validation_result: true,
         };
 
@@ -816,13 +810,11 @@ mod tests {
 
         let settings: Settings = Settings {
             signatures: vec![
-                Signature::PubKeys {
-                    0: PubKeys {
+                Signature::PubKeys(PubKeys {
                         image: "no_matching".to_string(),
                         pub_keys: vec![],
                         annotations: None,
-                    },
-                },
+                    }),
                 Signature::Keyless(Keyless {
                     image: "no_matching".to_string(),
                     keyless: vec![],
@@ -872,13 +864,11 @@ mod tests {
                     }],
                     annotations: None,
                 }),
-                Signature::PubKeys {
-                    0: PubKeys {
+                Signature::PubKeys(PubKeys {
                         image: "init".to_string(),
                         pub_keys: vec![],
                         annotations: None,
-                    },
-                },
+                    }),
             ],
             modify_images_with_digest: true,
         };
@@ -926,13 +916,11 @@ mod tests {
                     }],
                     annotations: None,
                 }),
-                Signature::PubKeys {
-                    0: PubKeys {
+                Signature::PubKeys(PubKeys {
                         image: "init".to_string(),
                         pub_keys: vec![],
                         annotations: None,
-                    },
-                },
+                    }),
             ],
             modify_images_with_digest: true,
         };
@@ -1000,7 +988,7 @@ mod tests {
         let tc = Testcase {
             name: String::from("It should successfully validate the nginx container"),
             fixture_file: String::from("test_data/pod_creation_with_digest.json"),
-            settings: settings,
+            settings,
             expected_validation_result: true,
         };
 
@@ -1036,7 +1024,7 @@ mod tests {
         let tc = Testcase {
             name: String::from("It should successfully validate the nginx container"),
             fixture_file: String::from("test_data/pod_creation_with_digest.json"),
-            settings: settings,
+            settings,
             expected_validation_result: true,
         };
 
@@ -1072,7 +1060,7 @@ mod tests {
         let tc = Testcase {
             name: String::from("It should successfully validate the nginx container"),
             fixture_file: String::from("test_data/pod_creation_with_digest.json"),
-            settings: settings,
+            settings,
             expected_validation_result: true,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,10 +552,10 @@ mod tests {
 
         let settings: Settings = Settings {
             signatures: vec![Signature::PubKeys(PubKeys {
-                    image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
-                    pub_keys: vec!["key".to_string()],
-                    annotations: None,
-                })],
+                image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
+                pub_keys: vec!["key".to_string()],
+                annotations: None,
+            })],
             modify_images_with_digest: true,
         };
 
@@ -601,10 +601,10 @@ mod tests {
 
         let settings: Settings = Settings {
             signatures: vec![Signature::PubKeys(PubKeys {
-                    image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
-                    pub_keys: vec!["key".to_string()],
-                    annotations: None,
-                })],
+                image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
+                pub_keys: vec!["key".to_string()],
+                annotations: None,
+            })],
             modify_images_with_digest: false,
         };
 
@@ -630,10 +630,10 @@ mod tests {
 
         let settings: Settings = Settings {
             signatures: vec![Signature::PubKeys(PubKeys {
-                    image: "*".to_string(),
-                    pub_keys: vec!["key".to_string()],
-                    annotations: None,
-                })],
+                image: "*".to_string(),
+                pub_keys: vec!["key".to_string()],
+                annotations: None,
+            })],
             modify_images_with_digest: true,
         };
 
@@ -811,10 +811,10 @@ mod tests {
         let settings: Settings = Settings {
             signatures: vec![
                 Signature::PubKeys(PubKeys {
-                        image: "no_matching".to_string(),
-                        pub_keys: vec![],
-                        annotations: None,
-                    }),
+                    image: "no_matching".to_string(),
+                    pub_keys: vec![],
+                    annotations: None,
+                }),
                 Signature::Keyless(Keyless {
                     image: "no_matching".to_string(),
                     keyless: vec![],
@@ -865,10 +865,10 @@ mod tests {
                     annotations: None,
                 }),
                 Signature::PubKeys(PubKeys {
-                        image: "init".to_string(),
-                        pub_keys: vec![],
-                        annotations: None,
-                    }),
+                    image: "init".to_string(),
+                    pub_keys: vec![],
+                    annotations: None,
+                }),
             ],
             modify_images_with_digest: true,
         };
@@ -917,10 +917,10 @@ mod tests {
                     annotations: None,
                 }),
                 Signature::PubKeys(PubKeys {
-                        image: "init".to_string(),
-                        pub_keys: vec![],
-                        annotations: None,
-                    }),
+                    image: "init".to_string(),
+                    pub_keys: vec![],
+                    annotations: None,
+                }),
             ],
             modify_images_with_digest: true,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,15 @@ use k8s_openapi::api::core::v1::{Container, EphemeralContainer, PodSpec, Replica
 extern crate kubewarden_policy_sdk as kubewarden;
 #[cfg(test)]
 use crate::tests::mock_sdk::{
-    verify_keyless_exact_match, verify_keyless_github_actions, verify_keyless_prefix_match,
-    verify_pub_keys_image,
+    verify_certificate, verify_keyless_exact_match, verify_keyless_github_actions,
+    verify_keyless_prefix_match, verify_pub_keys_image,
 };
 use anyhow::Result;
 use kubewarden::host_capabilities::verification::VerificationResponse;
 #[cfg(not(test))]
 use kubewarden::host_capabilities::verification::{
-    verify_keyless_exact_match, verify_keyless_github_actions, verify_keyless_prefix_match,
-    verify_pub_keys_image,
+    verify_certificate, verify_keyless_exact_match, verify_keyless_github_actions,
+    verify_keyless_prefix_match, verify_pub_keys_image,
 };
 use kubewarden::{logging, protocol_version_guest, request::ValidationRequest, validate_settings};
 use serde::de::DeserializeOwned;
@@ -380,6 +380,23 @@ where
                         );
                     }
                 }
+                Signature::Certificate(s) => {
+                    // verify if the name matches the image name provided
+                    if WildMatch::new(s.image.as_str()).matches(container_image.as_str()) {
+                        handle_verification_response(
+                            verify_certificate(
+                                container_image.as_str(),
+                                s.certificate.clone(),
+                                s.certificate_chain.clone(),
+                                s.require_rekor_bundle,
+                                s.annotations.clone(),
+                            ),
+                            container_image.as_str(),
+                            &mut container_with_images_digests[i],
+                            policy_verification_errors,
+                        );
+                    }
+                }
             }
         }
     }
@@ -432,7 +449,7 @@ fn add_digest_if_not_present<T>(
 mod tests {
     use super::*;
     use crate::settings::{
-        GithubActions, Keyless, KeylessGithubActionsInfo, KeylessPrefix, PubKeys,
+        Certificate, GithubActions, Keyless, KeylessGithubActionsInfo, KeylessPrefix, PubKeys,
     };
     use anyhow::anyhow;
     use kubewarden::host_capabilities::verification::{
@@ -503,6 +520,21 @@ mod tests {
                 digest: "mock_digest".to_string(),
             })
         }
+
+        // needed for creating mocks
+        #[allow(dead_code)]
+        pub fn verify_certificate(
+            _image: &str,
+            _certificate: String,
+            _certificate_chain: Option<Vec<String>>,
+            _require_rekor_bundle: bool,
+            _annotations: Option<HashMap<String, String>>,
+        ) -> Result<VerificationResponse> {
+            Ok(VerificationResponse {
+                is_trusted: true,
+                digest: "mock_digest".to_string(),
+            })
+        }
     }
 
     // these tests need to run sequentially because mockall creates a global context to create the mocks
@@ -532,7 +564,7 @@ mod tests {
         let tc = Testcase {
             name: String::from("It should successfully validate the ghcr.io/kubewarden/test-verify-image-signatures container"),
             fixture_file: String::from("test_data/pod_creation_signed.json"),
-            settings: settings,
+            settings,
             expected_validation_result: true,
         };
 
@@ -583,7 +615,7 @@ mod tests {
         let tc = Testcase {
             name: String::from("It should successfully validate the ghcr.io/kubewarden/test-verify-image-signatures container"),
             fixture_file: String::from("test_data/pod_creation_signed.json"),
-            settings: settings,
+            settings,
             expected_validation_result: true,
         };
 
@@ -701,6 +733,72 @@ mod tests {
 
         let response = tc.eval(validate).unwrap();
         assert_eq!(response.accepted, false)
+    }
+
+    #[test]
+    #[serial]
+    fn certificate_validation_pass_with_no_mutation() {
+        let ctx = mock_sdk::verify_certificate_context();
+        ctx.expect().times(1).returning(|_, _, _, _, _| {
+            Ok(VerificationResponse {
+                is_trusted: true,
+                digest: "sha256:89102e348749bb17a6a651a4b2a17420e1a66d2a44a675b981973d49a5af3a5e"
+                    .to_string(),
+            })
+        });
+
+        let settings: Settings = Settings {
+            signatures: vec![Signature::Certificate(Certificate {
+                image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
+                certificate: "cert".to_string(),
+                certificate_chain: None,
+                require_rekor_bundle: true,
+                annotations: None,
+            })],
+            modify_images_with_digest: false,
+        };
+
+        let tc = Testcase {
+            name: String::from("It should successfully validate the ghcr.io/kubewarden/test-verify-image-signatures container"),
+            fixture_file: String::from("test_data/pod_creation_signed.json"),
+            settings,
+            expected_validation_result: true,
+        };
+
+        let response = tc.eval(validate).unwrap();
+        assert_eq!(response.accepted, true);
+        assert!(response.mutated_object.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn certificate_validation_dont_pass() {
+        let ctx = mock_sdk::verify_certificate_context();
+        ctx.expect()
+            .times(1)
+            .returning(|_, _, _, _, _| Err(anyhow!("error")));
+
+        let settings: Settings = Settings {
+            signatures: vec![Signature::Certificate(Certificate {
+                image: "ghcr.io/kubewarden/test-verify-image-signatures:*".to_string(),
+                certificate: "cert".to_string(),
+                certificate_chain: None,
+                require_rekor_bundle: true,
+                annotations: None,
+            })],
+            modify_images_with_digest: true,
+        };
+
+        let tc = Testcase {
+            name: String::from("It should fail when validating the nginx container"),
+            fixture_file: String::from("test_data/pod_creation_signed.json"),
+            settings,
+            expected_validation_result: false,
+        };
+
+        let response = tc.eval(validate).unwrap();
+        assert_eq!(response.accepted, false);
+        assert!(response.mutated_object.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Allow uesrs to verify container images and other OCI artifacts using a certificate.

This is required to fix https://github.com/kubewarden/verify-image-signatures/issues/39
