### PR TITLE
fix: change settings keys to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ spec:
   settings:
     signatures:
     - image: "*"
-      github_actions:
+      githubActions:
         owner: "kubewarden"
         repo: "app-example" 
 ```
@@ -52,20 +52,20 @@ Signature types:
   ``` yaml
   signatures:
   - image: "ghcr.io/kubewarden/*"
-    github_actions:
+    githubActions:
       owner: "kubewarden"
       repo: "app-example" #optional
   ```
 
 2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
-   `url_prefix` is sanitized to prevent typosquatting.
+   `urlPrefix` is sanitized to prevent typosquatting.
 
   ``` yaml
   signatures:
   - image: "ghcr.io/kubewarden/*"
-    keyless_prefix:
+    keylessPrefix:
       - issuer: "https://token.actions.githubusercontent.com"
-        url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
+        urlPrefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
   ``` 
 
 
@@ -74,7 +74,7 @@ Signature types:
   ``` yaml
   modifyImagesWithDigest: false #optional. default is true
   signatures:
-    - image: "ghcr.io/kubewarden/*" 
+    - image: "ghcr.io/kubewarden/*"
       keyless:
         - issuer: "https://token.actions.githubusercontent.com"
           subject: "kubewarden"
@@ -94,9 +94,9 @@ Signature types:
 
 5. Certificate. It will verify that the image has been signed using the Certificate provided by the user.
   The `certificate` must be PEM encoded. Optionally the settings can have
-  the list of PEM encoded certificates that can create the `certificate_chain`
+  the list of PEM encoded certificates that can create the `certificateChain`
   used to verify the given `certificate`.
-  The `require_rekor_bundle` should be set to `true` to have a stronger
+  The `requireRekorBundle` should be set to `true` to have a stronger
   verification process. When set to `true`, the signature must have a Rekor
   bundle and the signature must have been created during the validity
   time frame of the `certificate`.
@@ -108,7 +108,7 @@ Signature types:
         -----BEGIN CERTIFICATE-----
         XXX
         -----END CERTIFICATE-----
-      certificate_chain:
+      certificateChain:
       - |
         -----BEGIN CERTIFICATE-----
         <intermediate cert>
@@ -117,7 +117,7 @@ Signature types:
         -----BEGIN CERTIFICATE-----
         <root CA>
         -----END CERTIFICATE-----
-      require_rekor_bundle: true
+      requireRekorBundle: true
   ```
 
 ## License

--- a/metadata.yml
+++ b/metadata.yml
@@ -44,7 +44,7 @@ annotations:
       settings:
         signatures:
           - image: "*"
-            github_actions:
+            githubActions:
               owner: "kubewarden"
               repo: "app-example"
     ```
@@ -64,20 +64,20 @@ annotations:
       ``` yaml
       signatures:
       - image: "ghcr.io/kubewarden/*"
-        github_actions:
+        githubActions:
           owner: "kubewarden"
           repo: "app-example" #optional
       ```
 
     2. Keyless subject prefix. It will verify that the issuer is `https://token.actions.githubusercontent.com` and the subject starts with `https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/`
-       `url_prefix` is sanitized to prevent typosquatting.
+       `urlPrefix` is sanitized to prevent typosquatting.
 
       ``` yaml
       signatures:
       - image: "ghcr.io/kubewarden/*"
-        keyless_prefix:
+        keylessPrefix:
           - issuer: "https://token.actions.githubusercontent.com"
-            url_prefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
+            urlPrefix: "https://github.com/kubewarden/app-example/.github/workflows/ci.yml@refs/tags/"
       ```
 
 
@@ -106,9 +106,9 @@ annotations:
 
     5. Certificate. It will verify that the image has been signed using the Certificate provided by the user.
       The `certificate` must be PEM encoded. Optionally the settings can have
-      the list of PEM encoded certificates that can create the `certificate_chain`
+      the list of PEM encoded certificates that can create the `certificateChain`
       used to verify the given `certificate`.
-      The `require_rekor_bundle` should be set to `true` to have a stronger
+      The `requireRekorBundle` should be set to `true` to have a stronger
       verification process. When set to `true`, the signature must have a Rekor
       bundle and the signature must have been created during the validity
       time frame of the `certificate`.
@@ -120,7 +120,7 @@ annotations:
             -----BEGIN CERTIFICATE-----
             XXX
             -----END CERTIFICATE-----
-          certificate_chain:
+          certificateChain:
           - |
             -----BEGIN CERTIFICATE-----
             <intermediate cert>
@@ -129,5 +129,5 @@ annotations:
             -----BEGIN CERTIFICATE-----
             <root CA>
             -----END CERTIFICATE-----
-          require_rekor_bundle: true
+          requireRekorBundle: true
       ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,7 +19,7 @@ pub(crate) struct Settings {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "camelCase")]
 pub(crate) enum Signature {
     PubKeys(PubKeys),
     Keyless(Keyless),
@@ -37,6 +37,7 @@ pub(crate) struct PubKeys {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct Keyless {
     pub(crate) image: String,
     pub(crate) keyless: Vec<KeylessInfo>,
@@ -44,6 +45,7 @@ pub(crate) struct Keyless {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct KeylessGithubActionsInfo {
     /// owner of the repository. E.g: octocat
     pub(crate) owner: String,
@@ -52,6 +54,7 @@ pub(crate) struct KeylessGithubActionsInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct GithubActions {
     /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
     pub(crate) image: String,
@@ -62,6 +65,7 @@ pub(crate) struct GithubActions {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct Certificate {
     /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
     pub(crate) image: String,
@@ -83,6 +87,7 @@ pub(crate) struct Certificate {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct KeylessPrefix {
     /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
     pub(crate) image: String,


### PR DESCRIPTION
Ensure all the keys of the settings are following the `camelCase` naming convention.

Fixes https://github.com/kubewarden/verify-image-signatures/issues/42
