### PR TITLE
Verify certs in settings validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e164eef7c4defa524673223cac3c51644f16b3f09167fa6dd5a6f0dcc1185ff"
+checksum = "53e35080e4c03d52b6fba0d230f831651088c30d955167cd2062d82b586f4fb6"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = "1.0"
 slog = "2.7"
 wildmatch = "2.1.1"
 anyhow = "1.0"
-chrono = "0.4.23"
 
 [dev-dependencies]
 rstest = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 k8s-openapi = { version = "0.16.0", default_features = false, features = ["v1_24"] }
-kubewarden-policy-sdk = "0.8.4"
+kubewarden-policy-sdk = "0.8.5"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 slog = "2.7"
 wildmatch = "2.1.1"
 anyhow = "1.0"
+chrono = "0.4.23"
 
 [dev-dependencies]
 rstest = "0.16.0"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,7 +5,6 @@ use kubewarden::host_capabilities::crypto::{
 use kubewarden::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use std::collections::HashMap;
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use slog::info;
 
@@ -131,13 +130,13 @@ impl kubewarden::settings::Validatable for Settings {
                     }
                     None => None,
                 };
-                match verify_cert(cert, cert_chain_opt, Some(Utc::now().to_rfc3339())) {
                     Ok(verified) => {
                         if !verified {
                             return Err(format!(
                                 "Signatures for image {:?}: Certificate not trusted",
                                 s.image
                             ));
+                match verify_cert(cert, cert_chain_opt, None) {
                         }
                     }
                     Err(e) => {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -188,4 +188,23 @@ mod tests {
         assert!(settings.validate().is_err());
         Ok(())
     }
+
+    #[test]
+    fn validate_settings_invalid_cert() -> Result<(), ()> {
+        let settings = Settings {
+            signatures: vec![Signature::Certificate(Certificate {
+                image: "myimage".to_string(),
+                certificate: "this is not a PEM cert".to_string(),
+                certificate_chain: None,
+                require_rekor_bundle: false,
+                annotations: None,
+            })],
+            modify_images_with_digest: true,
+        };
+
+        assert!(settings.validate().is_err());
+        // not checking error msg as we are using mocks
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/verify-image-signatures/issues/44

For those certs passed in `Signature::certificate`, verify them against
the provided cert chain. Also check the cert validity time, and
expiration time (using current time).

Bump version to `0.1.8`.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

The certificate side is tested as part of the sdk.
The construction of the structs and calls to `verify_cert()`, but is simple enough.


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
