### PR TITLE
feat: cert verification, support multiple certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ Signature types:
         env: prod
   ``` 
 
-5. Certificate. It will verify that the image has been signed using the Certificate provided by the user.
-  The `certificate` must be PEM encoded. Optionally the settings can have
+5. Certificate. It will verify that the image has been signed using all the
+  certificates provided by the user.
+  The certificates must be PEM encoded. Optionally the settings can have
   the list of PEM encoded certificates that can create the `certificateChain`
   used to verify the given `certificate`.
   The `requireRekorBundle` should be set to `true` to have a stronger
@@ -101,12 +102,20 @@ Signature types:
   bundle and the signature must have been created during the validity
   time frame of the `certificate`.
 
+  The following configuration requires all the container images coming from
+  `registry.acme.org/secure-project` to be signed both by Alice and by Bob.
+
   ```yaml
   signatures:
-    - image: "registry-testing.svc.lan/kubewarden/pod-privileged:v0.1.9"
-      certificate: |
+    - image: "registry.acme.org/secure-project/*"
+      certificates:
+      - |
         -----BEGIN CERTIFICATE-----
-        XXX
+        alice's cert
+        -----END CERTIFICATE-----
+      - |
+        -----BEGIN CERTIFICATE-----
+        bob's cert
         -----END CERTIFICATE-----
       certificateChain:
       - |
@@ -118,7 +127,10 @@ Signature types:
         <root CA>
         -----END CERTIFICATE-----
       requireRekorBundle: true
+      annotations: #optional
+        env: prod
   ```
+
 
 ## License
 

--- a/metadata.yml
+++ b/metadata.yml
@@ -104,8 +104,9 @@ annotations:
             env: prod
       ```
 
-    5. Certificate. It will verify that the image has been signed using the Certificate provided by the user.
-      The `certificate` must be PEM encoded. Optionally the settings can have
+    5. Certificate. It will verify that the image has been signed using all the
+      certificates provided by the user.
+      The certificates must be PEM encoded. Optionally the settings can have
       the list of PEM encoded certificates that can create the `certificateChain`
       used to verify the given `certificate`.
       The `requireRekorBundle` should be set to `true` to have a stronger
@@ -113,12 +114,20 @@ annotations:
       bundle and the signature must have been created during the validity
       time frame of the `certificate`.
 
+      The following configuration requires all the container images coming from
+      `registry.acme.org/secure-project` to be signed both by Alice and by Bob.
+
       ```yaml
       signatures:
-        - image: "registry-testing.svc.lan/kubewarden/pod-privileged:v0.1.9"
-          certificate: |
+        - image: "registry.acme.org/secure-project/*"
+          certificates:
+          - |
             -----BEGIN CERTIFICATE-----
-            XXX
+            alice's cert
+            -----END CERTIFICATE-----
+          - |
+            -----BEGIN CERTIFICATE-----
+            bob's cert
             -----END CERTIFICATE-----
           certificateChain:
           - |
@@ -130,4 +139,6 @@ annotations:
             <root CA>
             -----END CERTIFICATE-----
           requireRekorBundle: true
+          annotations: #optional
+            env: prod
       ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use k8s_openapi::api::core::v1::{Container, EphemeralContainer, PodSpec, Replica
 
 extern crate kubewarden_policy_sdk as kubewarden;
 #[cfg(test)]
-use crate::tests::mock_sdk::{
+use crate::tests::mock_verification_sdk::{
     verify_certificate, verify_keyless_exact_match, verify_keyless_github_actions,
     verify_keyless_prefix_match, verify_pub_keys_image,
 };
@@ -473,7 +473,7 @@ mod tests {
     use serial_test::serial;
 
     #[automock()]
-    pub mod sdk {
+    pub mod verification_sdk {
         use anyhow::Result;
         use kubewarden::host_capabilities::verification::{
             KeylessInfo, KeylessPrefixInfo, VerificationResponse,
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     #[serial]
     fn pub_keys_validation_pass_with_mutation() {
-        let ctx = mock_sdk::verify_pub_keys_image_context();
+        let ctx = mock_verification_sdk::verify_pub_keys_image_context();
         ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     #[serial]
     fn pub_keys_validation_pass_with_no_mutation() {
-        let ctx = mock_sdk::verify_pub_keys_image_context();
+        let ctx = mock_verification_sdk::verify_pub_keys_image_context();
         ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     #[serial]
     fn pub_keys_validation_dont_pass() {
-        let ctx = mock_sdk::verify_pub_keys_image_context();
+        let ctx = mock_verification_sdk::verify_pub_keys_image_context();
         ctx.expect()
             .times(1)
             .returning(|_, _, _| Err(anyhow!("error")));
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     #[serial]
     fn keyless_validation_pass_with_mutation() {
-        let ctx = mock_sdk::verify_keyless_exact_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -716,7 +716,7 @@ mod tests {
     #[test]
     #[serial]
     fn keyless_validation_dont_pass() {
-        let ctx = mock_sdk::verify_keyless_exact_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx.expect()
             .times(1)
             .returning(|_, _, _| Err(anyhow!("error")));
@@ -744,7 +744,7 @@ mod tests {
     #[test]
     #[serial]
     fn certificate_validation_pass_with_no_mutation() {
-        let ctx = mock_sdk::verify_certificate_context();
+        let ctx = mock_verification_sdk::verify_certificate_context();
         ctx.expect()
             .times(1)
             .returning(|_, certificate, _, _, _| match certificate.as_str() {
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     #[serial]
     fn certificate_validation_pass_with_multiple_good_keys() {
-        let ctx = mock_sdk::verify_certificate_context();
+        let ctx = mock_verification_sdk::verify_certificate_context();
         ctx.expect()
             .times(2)
             .returning(|_, certificate, _, _, _| match certificate.as_str() {
@@ -822,7 +822,7 @@ mod tests {
     #[test]
     #[serial]
     fn certificate_validation_dont_pass() {
-        let ctx = mock_sdk::verify_certificate_context();
+        let ctx = mock_verification_sdk::verify_certificate_context();
         ctx.expect()
             .times(2)
             .returning(|_, certificate, _, _, _| match certificate.as_str() {
@@ -862,12 +862,12 @@ mod tests {
     #[test]
     #[serial]
     fn validation_pass_when_there_is_no_matching_containers() {
-        let ctx = mock_sdk::verify_pub_keys_image_context();
+        let ctx = mock_verification_sdk::verify_pub_keys_image_context();
         ctx.expect()
             .times(0)
             .returning(|_, _, _| Err(anyhow!("error")));
 
-        let ctx = mock_sdk::verify_keyless_exact_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx.expect()
             .times(0)
             .returning(|_, _, _| Err(anyhow!("error")));
@@ -903,7 +903,7 @@ mod tests {
     #[test]
     #[serial]
     fn validation_with_multiple_containers_fail_if_one_fails() {
-        let ctx_pub_keys = mock_sdk::verify_pub_keys_image_context();
+        let ctx_pub_keys = mock_verification_sdk::verify_pub_keys_image_context();
         ctx_pub_keys.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -912,7 +912,7 @@ mod tests {
             })
         });
 
-        let ctx_keyless = mock_sdk::verify_keyless_exact_match_context();
+        let ctx_keyless = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx_keyless
             .expect()
             .times(1)
@@ -952,7 +952,7 @@ mod tests {
     #[test]
     #[serial]
     fn validation_with_multiple_containers_with_mutation_pass() {
-        let ctx_pub_keys = mock_sdk::verify_pub_keys_image_context();
+        let ctx_pub_keys = mock_verification_sdk::verify_pub_keys_image_context();
         ctx_pub_keys.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -961,7 +961,7 @@ mod tests {
             })
         });
 
-        let ctx_keyless = mock_sdk::verify_keyless_exact_match_context();
+        let ctx_keyless = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx_keyless.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -1028,7 +1028,7 @@ mod tests {
     #[test]
     #[serial]
     fn keyless_validation_pass_and_dont_mutate_if_digest_is_present() {
-        let ctx = mock_sdk::verify_keyless_exact_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -1064,7 +1064,7 @@ mod tests {
     #[test]
     #[serial]
     fn keyless_prefix_validation_pass_and_dont_mutate_if_digest_is_present() {
-        let ctx = mock_sdk::verify_keyless_prefix_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_prefix_match_context();
         ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -1100,7 +1100,7 @@ mod tests {
     #[test]
     #[serial]
     fn keyless_github_action_validation_pass_and_dont_mutate_if_digest_is_present() {
-        let ctx = mock_sdk::verify_keyless_github_actions_context();
+        let ctx = mock_verification_sdk::verify_keyless_github_actions_context();
         ctx.expect().times(1).returning(|_, _, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -1134,7 +1134,7 @@ mod tests {
     }
 
     fn resource_validation_pass(file: &str) {
-        let ctx = mock_sdk::verify_keyless_exact_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx.expect().times(1).returning(|_, _, _| {
             Ok(VerificationResponse {
                 is_trusted: true,
@@ -1167,7 +1167,7 @@ mod tests {
     }
 
     fn resource_validation_reject(file: &str) {
-        let ctx = mock_sdk::verify_keyless_exact_match_context();
+        let ctx = mock_verification_sdk::verify_keyless_exact_match_context();
         ctx.expect()
             .times(1)
             .returning(|_, _, _| Err(anyhow!("error")));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,6 +473,21 @@ mod tests {
     use serial_test::serial;
 
     #[automock()]
+    pub mod crypto_sdk {
+        use anyhow::Result;
+        use kubewarden::host_capabilities::crypto::{BoolWithReason, Certificate};
+
+        #[allow(dead_code)]
+        pub fn verify_cert(
+            _cert: Certificate,
+            _cert_chain: Option<Vec<Certificate>>,
+            _not_after: Option<String>,
+        ) -> Result<BoolWithReason> {
+            Ok(BoolWithReason::True)
+        }
+    }
+
+    #[automock()]
     pub mod verification_sdk {
         use anyhow::Result;
         use kubewarden::host_capabilities::verification::{

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -73,7 +73,7 @@ pub(crate) struct Certificate {
     /// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
     pub(crate) image: String,
     /// PEM encoded certificate used to verify the signature
-    pub(crate) certificate: String,
+    pub(crate) certificates: Vec<String>,
     /// Optional - the certificate chain that is used to verify the provided
     /// certificate. When not specified, the certificate is assumed to be trusted
     pub(crate) certificate_chain: Option<Vec<String>>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,9 +1,17 @@
 use crate::LOG_DRAIN;
 use kubewarden::host_capabilities::crypto::{
-    verify_cert, BoolWithReason, Certificate as SDKCert, CertificateEncoding,
+    BoolWithReason, Certificate as SDKCert, CertificateEncoding,
 };
+
+#[cfg(test)]
+use crate::tests::mock_crypto_sdk::verify_cert;
+
+#[cfg(not(test))]
+use kubewarden::host_capabilities::crypto::verify_cert;
+
 use kubewarden::host_capabilities::verification::{KeylessInfo, KeylessPrefixInfo};
 use std::collections::HashMap;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use slog::info;
@@ -31,6 +39,32 @@ pub(crate) enum Signature {
     Certificate(Certificate),
 }
 
+impl fmt::Display for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let detailed_display = match self {
+            Signature::PubKeys(pub_keys) => pub_keys.to_string(),
+            Signature::Keyless(keyless) => keyless.to_string(),
+            Signature::GithubActions(github_action) => github_action.to_string(),
+            Signature::KeylessPrefix(keyless_prefix) => keyless_prefix.to_string(),
+            Signature::Certificate(cert) => cert.to_string(),
+        };
+
+        write!(f, "{}", detailed_display)
+    }
+}
+
+impl Signature {
+    fn validate(&self) -> Result<(), String> {
+        match self {
+            Signature::PubKeys(_) => Ok(()),
+            Signature::Keyless(_) => Ok(()),
+            Signature::GithubActions(_) => Ok(()),
+            Signature::KeylessPrefix(_) => Ok(()),
+            Signature::Certificate(cert) => cert.validate(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PubKeys {
@@ -39,12 +73,24 @@ pub(crate) struct PubKeys {
     pub(crate) annotations: Option<HashMap<String, String>>,
 }
 
+impl fmt::Display for PubKeys {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Pub key signature for image {}", self.image)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Keyless {
     pub(crate) image: String,
     pub(crate) keyless: Vec<KeylessInfo>,
     pub(crate) annotations: Option<HashMap<String, String>>,
+}
+
+impl fmt::Display for Keyless {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Keyless signature for image {}", self.image)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -65,6 +111,12 @@ pub(crate) struct GithubActions {
     pub(crate) github_actions: KeylessGithubActionsInfo,
     /// Optional - Annotations that must have been provided by all signers when they signed the OCI artifact
     pub(crate) annotations: Option<HashMap<String, String>>,
+}
+
+impl fmt::Display for GithubActions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GitHub action signature for image {}", self.image)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -89,6 +141,60 @@ pub(crate) struct Certificate {
     pub(crate) annotations: Option<HashMap<String, String>>,
 }
 
+impl fmt::Display for Certificate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Certificate signature for image {}", self.image)
+    }
+}
+impl Certificate {
+    fn validate(&self) -> Result<(), String> {
+        if self.certificates.is_empty() {
+            return Err("no certificate provided".to_string());
+        }
+
+        let cert_chain_opt: Option<Vec<SDKCert>> = self.certificate_chain.as_ref().map({
+            |chain| {
+                chain
+                    .iter()
+                    .map(|c| SDKCert {
+                        encoding: CertificateEncoding::Pem,
+                        data: c.to_owned().into_bytes(),
+                    })
+                    .collect()
+            }
+        });
+
+        let validation_errors: Vec<String> = self
+            .certificates
+            .iter()
+            .filter_map(|c| {
+                let sdk_cert = SDKCert {
+                    encoding: CertificateEncoding::Pem,
+                    data: c.to_owned().into_bytes(),
+                };
+                match verify_cert(sdk_cert, cert_chain_opt.clone(), None) {
+                    Ok(b) => match b {
+                        BoolWithReason::True => None,
+                        BoolWithReason::False(reason) => {
+                            Some(format!("Certificate not trusted: {}", reason))
+                        }
+                    },
+                    Err(e) => Some(format!(
+                        "Error when verifying certificate: {:?}",
+                        e.to_string()
+                    )),
+                }
+            })
+            .collect();
+
+        if validation_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(validation_errors.join("; "))
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct KeylessPrefix {
@@ -100,6 +206,12 @@ pub(crate) struct KeylessPrefix {
     pub(crate) annotations: Option<HashMap<String, String>>,
 }
 
+impl fmt::Display for KeylessPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Keyless signature for image {}", self.image)
+    }
+}
+
 impl kubewarden::settings::Validatable for Settings {
     fn validate(&self) -> Result<(), String> {
         info!(LOG_DRAIN, "starting settings validation");
@@ -108,59 +220,33 @@ impl kubewarden::settings::Validatable for Settings {
             return Err("Signatures must not be empty".to_string());
         }
 
-        // when a certificate is being used, ensure it can be trusted
-        'signatures: for signature in self.signatures.iter() {
-            if let Signature::Certificate(s) = signature {
-                // build sdk structs:
-                let cert = SDKCert {
-                    encoding: CertificateEncoding::Pem,
-                    data: s.certificate.to_owned().into_bytes(),
-                };
-                let cert_chain_opt: Option<Vec<SDKCert>> = s.certificate_chain.as_ref().map({
-                    |chain| {
-                        chain
-                            .iter()
-                            .map(|c| SDKCert {
-                                encoding: CertificateEncoding::Pem,
-                                data: c.to_owned().into_bytes(),
-                            })
-                            .collect()
-                    }
-                });
+        let validation_errors: Vec<String> = self
+            .signatures
+            .iter()
+            .filter_map(|s| match s.validate() {
+                Ok(_) => None,
+                Err(e) => Some(format!("{}: {:?}", s, e)),
+            })
+            .collect();
 
-                match verify_cert(cert, cert_chain_opt, None) {
-                    Ok(b) => {
-                        match b {
-                            BoolWithReason::True => continue 'signatures, // cert verified
-                            BoolWithReason::False(reason) => {
-                                return Err(format!(
-                                    "Signatures for image {}: Certificate not trusted: {}",
-                                    s.image, reason
-                                ))
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        return Err(format!(
-                            "Signatures for image {}: Error when verifying certificate: {:?}",
-                            s.image,
-                            e.to_string()
-                        ))
-                    }
-                };
-            }
+        if validation_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(validation_errors.join("; "))
         }
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::mock_crypto_sdk;
 
     use kubewarden_policy_sdk::settings::Validatable;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn validate_settings_valid() -> Result<(), ()> {
         let settings = Settings {
             signatures: vec![Signature::Keyless(Keyless {
@@ -179,7 +265,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn validate_settings_empty_signatures() -> Result<(), ()> {
+        let ctx = mock_crypto_sdk::verify_cert_context();
+        ctx.expect()
+            .times(0)
+            .returning(|_cert, _cert_chain, _not_after| Ok(BoolWithReason::True));
+
         let settings = Settings {
             signatures: vec![],
             modify_images_with_digest: true,
@@ -190,11 +282,19 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn validate_settings_invalid_cert() -> Result<(), ()> {
+        let ctx = mock_crypto_sdk::verify_cert_context();
+        ctx.expect()
+            .times(1)
+            .returning(|_cert, _cert_chain, _not_after| {
+                Ok(BoolWithReason::False("not a valid cert".to_string()))
+            });
+
         let settings = Settings {
             signatures: vec![Signature::Certificate(Certificate {
                 image: "myimage".to_string(),
-                certificate: "this is not a PEM cert".to_string(),
+                certificates: vec!["this is not a PEM cert".to_string()],
                 certificate_chain: None,
                 require_rekor_bundle: false,
                 annotations: None,
@@ -202,9 +302,12 @@ mod tests {
             modify_images_with_digest: true,
         };
 
-        assert!(settings.validate().is_err());
-        // not checking error msg as we are using mocks
-
+        let result = settings.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            "Certificate signature for image myimage: \"Certificate not trusted: not a valid cert\"",
+            result.unwrap_err()
+        );
         Ok(())
     }
 }

--- a/test_data/settings-pod_signed_with_cert_and_rekor.yaml
+++ b/test_data/settings-pod_signed_with_cert_and_rekor.yaml
@@ -2,7 +2,8 @@
 # behavior
 signatures:
   - image: "ghcr.io/kubewarden/tests/pod-privileged:v0.2.1"
-    certificate: |
+    certificates:
+    - |
       -----BEGIN CERTIFICATE-----
       MIICsjCCAligAwIBAgIUZfoeZRPm91CZevZ1fPbn4+KRd0owCgYIKoZIzj0EAwIw
       gZIxCzAJBgNVBAYTAkRFMRAwDgYDVQQIEwdCYXZhcmlhMRIwEAYDVQQHEwlOdXJl


### PR DESCRIPTION
Allow multiple certificates to be specified when doing cert-based verification.

All the certs are put in `AND` condition.

Fixes: https://github.com/kubewarden/verify-image-signatures/issues/49
