### PR TITLE
Update questions - Fix typo in Certificates label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "verify-image-signatures"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verify-image-signatures"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["raulcabello <raul.cabello@suse.com>","viccuad <vcuadradojuan@suse.de>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.2
+version: 0.2.3
 name: verify-image-signatures
 displayName: Verify Image Signatures
 createdAt: '2023-02-17T16:14:24+00:00'
@@ -9,7 +9,7 @@ license: Apache-2.0
 homeURL: https://github.com/kubewarden/verify-image-signatures
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.2
+  image: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.3
 keywords:
 - pod
 - signature
@@ -17,7 +17,7 @@ keywords:
 - trusted
 links:
 - name: policy
-  url: https://github.com/kubewarden/verify-image-signatures/releases/download/v0.2.2/policy.wasm
+  url: https://github.com/kubewarden/verify-image-signatures/releases/download/v0.2.3/policy.wasm
 - name: source
   url: https://github.com/kubewarden/verify-image-signatures
 provider:
@@ -231,7 +231,7 @@ annotations:
           variable: image
         - default: []
           group: Settings
-          label: Public keys
+          label: Certificates
           show_if: rule=Certificate
           type: array[
           value_multiline: true

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -2,7 +2,7 @@
 version: 0.2.3
 name: verify-image-signatures
 displayName: Verify Image Signatures
-createdAt: '2023-02-17T16:14:24+00:00'
+createdAt: '2023-02-28T13:12:33+00:00'
 description: A Kubewarden Policy that verifies all the signatures of the container
   images referenced by a Pod
 license: Apache-2.0

--- a/questions-ui.yml
+++ b/questions-ui.yml
@@ -194,7 +194,7 @@ questions:
       variable: image
     - default: []
       group: Settings
-      label: Public keys
+      label: Certificates
       show_if: rule=Certificate
       type: array[
       value_multiline: true


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/ui/issues/265

This fixes a typo for the Certificates question label, it was set as "Public Keys" when it should be "Certificates"