### PR TITLE
chore: Bump rust edition to 2021

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "verify-image-signatures"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verify-image-signatures"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Raul Cabello <raul.cabello@suse.com>","Víctor Cuadrado <vcuadradojuan@suse.de>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verify-image-signatures"
 version = "0.2.6"
-authors = ["raulcabello <raul.cabello@suse.com>","viccuad <vcuadradojuan@suse.de>"]
+authors = ["Raul Cabello <raul.cabello@suse.com>","Víctor Cuadrado <vcuadradojuan@suse.de>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "verify-image-signatures"
 version = "0.2.6"
 authors = ["raulcabello <raul.cabello@suse.com>","viccuad <vcuadradojuan@suse.de>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.6
+version: 0.2.7
 name: verify-image-signatures
 displayName: Verify Image Signatures
-createdAt: 2023-03-24T16:18:04.159529845Z
+createdAt: 2023-05-22T09:45:33.188343425Z
 description: A Kubewarden Policy that verifies all the signatures of the container images referenced by a Pod
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/verify-image-signatures
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.6
+  image: ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.7
 keywords:
 - pod
 - signature
@@ -21,13 +21,13 @@ keywords:
 - trusted
 links:
 - name: policy
-  url: https://github.com/kubewarden/verify-image-signatures/releases/download/v0.2.6/policy.wasm
+  url: https://github.com/kubewarden/verify-image-signatures/releases/download/v0.2.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/verify-image-signatures
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.6
+  kwctl pull ghcr.io/kubewarden/policies/verify-image-signatures:v0.2.7
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

chore: Bump rust edition to 2021
chore: Fix authors names
build: Bump version to 0.2.7

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
E2E tests fine.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
