### PR TITLE
chore: add Kubewarden repository badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Kubewarden Policy Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-policies.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#policy-scope)
+[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
+
 # Kubewarden policy verify-image-signatures
 
 ## Description


### PR DESCRIPTION
## Description

Adds the Kubewarden repository badges document the scope and status of the repository in the Kubewarden ecosystem.

Related to https://github.com/kubewarden/kubewarden-controller/issues/727