### PR TITLE
chore(deps): move to wasm32-wasip1 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ SOURCE_FILES := $(shell test -e src/ && find src -type f)
 VERSION := $(shell sed --posix -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
-	cargo build --target=wasm32-wasi --release
-	cp target/wasm32-wasi/release/*.wasm policy.wasm
+	cargo build --target=wasm32-wasip1 --release
+	cp target/wasm32-wasip1/release/*.wasm policy.wasm
 
 artifacthub-pkg.yml: metadata.yml Cargo.toml
 	kwctl scaffold artifacthub --metadata-path metadata.yml --version $(VERSION) \


### PR DESCRIPTION
The `wasm32-wasi` target is deprecated and is has already been renamed `wasm32-wasip1`

See https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html
