### PR TITLE
feat: mutate all types of resources

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - 'v*'
+      - "v*"
 
 name: Release policy
 
 jobs:
-
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.3
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.4
 
   release:
     needs: test
@@ -23,6 +22,6 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v3.3.3
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v3.3.4
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/verify-image-signatures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,4 +3,4 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.3
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-k8s-openapi = { version = "0.22.0", default_features = false, features = [
+k8s-openapi = { version = "0.22.0", default-features = false, features = [
   "v1_27",
 ] }
 kubewarden-policy-sdk = "0.11.0"

--- a/e2e.bats
+++ b/e2e.bats
@@ -18,7 +18,7 @@
 
   [ "$status" -eq 0 ]
   [ $(expr "$output" : '.*"allowed":false.*') -ne 0 ]
-  [ $(expr "$output" : '.*"message":"Pod invalid-pod-name is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
+  [ $(expr "$output" : '.*"message":"Resource invalid-pod-name is not accepted: verification of image ghcr.io/kubewarden/test-verify-image-signatures:unsigned failed.*') -ne 0 ]
 }
 
 @test "Mutate Pod definition" {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -60,6 +60,16 @@ impl fmt::Display for Signature {
 }
 
 impl Signature {
+    pub fn image(&self) -> &str {
+        match self {
+            Signature::PubKeys(s) => s.image.as_str(),
+            Signature::Keyless(s) => s.image.as_str(),
+            Signature::GithubActions(s) => s.image.as_str(),
+            Signature::KeylessPrefix(s) => s.image.as_str(),
+            Signature::Certificate(s) => s.image.as_str(),
+        }
+    }
+
     fn validate(&self) -> Result<(), String> {
         match self {
             Signature::PubKeys(pub_keys) => pub_keys.validate().map_err(|e| e.to_string()),


### PR DESCRIPTION
Allow the policy to mutate not only Pods, but also Deployments, ReplicaSets, DaemonSets,...

While doing that I also refactored the code, removing some repetition and I cleaned up the unit tests.

Note: I would also like to split the contents of `lib.rs` into smaller files, but I don't know if this is something to be done with this PR or with another one.
