### PR TITLE
ci: Add .yml workflows

### DIFF
--- a/.github/workflows/verify-image-signatures/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/verify-image-signatures/.github/workflows/open-release-pr.yml
@@ -1,0 +1,14 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 3 12 * *" # At 03:30 on day-of-month 12
+
+name: Open release PR
+
+jobs:
+  test:
+    name: open-release-pr
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-pr.yml@v4.4.0
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/verify-image-signatures/.github/workflows/release-tag.yml
+++ b/.github/workflows/verify-image-signatures/.github/workflows/release-tag.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      trigger_release:
+        description: "Tag and trigger release manually"
+        required: false
+        default: true
+
+name: Tag and Release on PR Merge
+
+jobs:
+  test:
+    name: release-tag
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-tag.yml@v4.4.0


### PR DESCRIPTION
This pr adds the workflow files open-release-pr.yml and release-tag.yml:

- open-release-pr workflow runs monthly on the 12th day of the month, creating
  a PR to bump the needed version metadata, labeled `TRIGGER-RELEASE`.
- release-tag workflow checks all merged PRs, if they are labeled
  `TRIGGER-RELEASE`, it will create a tag so a release is performed.
